### PR TITLE
Foi adicionado o gerenciamento de Session no Sistema para o IdFrota

### DIFF
--- a/Codigo/Frota/Core/Service/IAbastecimentoService.cs
+++ b/Codigo/Frota/Core/Service/IAbastecimentoService.cs
@@ -1,15 +1,12 @@
-﻿using Core.Datatables;
-
-namespace Core.Service
+﻿namespace Core.Service
 {
     public interface IAbastecimentoService
     {
-        uint Create(Abastecimento abastecimento);
-        void Edit(Abastecimento abastecimento);
+        uint Create(Abastecimento abastecimento, int idFrota);
+        void Edit(Abastecimento abastecimento, int idFrota);
         void Delete(uint idAbastecimento);
         Abastecimento? Get(uint idAbastecimento);
-        IEnumerable<Abastecimento> GetPaged(int page, int lenght);
-        IEnumerable<Abastecimento> GetAll();
-        DatatableResponse<Abastecimento> GetDataPage(DatatableRequest request);
+        IEnumerable<Abastecimento> GetPaged(int page, int lenght, int idFrota);
+        IEnumerable<Abastecimento> GetAll(int idFrota);
     }
 }

--- a/Codigo/Frota/Core/Service/IFrotaService.cs
+++ b/Codigo/Frota/Core/Service/IFrotaService.cs
@@ -6,9 +6,9 @@ namespace Core.Service
     {
         uint Create(Frotum frota);
         void Edit(Frotum frota);
-        bool Delete(uint idFrota);
-        Frotum? Get(uint idFrota);
-        uint GetFrotaByUser();
+        bool Delete(int idFrota);
+        Frotum? Get(int idFrota);
+        uint GetFrotaByUsername(string username);
         IEnumerable<Frotum> GetAll();
         IEnumerable<FrotaDTO> GetAllOrdemAlfabetica();
 

--- a/Codigo/Frota/Core/Service/IPessoaService.cs
+++ b/Codigo/Frota/Core/Service/IPessoaService.cs
@@ -2,12 +2,12 @@
 {
     public interface IPessoaService
     {
-        uint Create(Pessoa pessoa);
-        void Edit(Pessoa pessoa);
+        uint Create(Pessoa pessoa, int idFrota);
+        void Edit(Pessoa pessoa, int idFrota);
         void Delete(uint idPessoa);
-        IEnumerable<Pessoa> GetAll();
+        IEnumerable<Pessoa> GetAll(int idFrota);
         Pessoa? Get(uint idPessoa);
         uint GetPessoaIdUser();
-        IEnumerable<Pessoa> GetPaged(int page, int lenght, out int totalResults, string search = null, string filterBy = "Nome");
+        IEnumerable<Pessoa> GetPaged(int idFrota, int page, int lenght, out int totalResults, string search = null, string filterBy = "Nome");
     }
 }

--- a/Codigo/Frota/Core/Service/IVeiculoService.cs
+++ b/Codigo/Frota/Core/Service/IVeiculoService.cs
@@ -4,13 +4,13 @@ namespace Core.Service
 {
     public interface IVeiculoService
     {
-        uint Create(Veiculo veiculo);
-        void Edit(Veiculo veiculo);
+        uint Create(Veiculo veiculo, int idFrota);
+        void Edit(Veiculo veiculo, int idFrota);
         void Delete(uint idVeiculo);
         Veiculo? Get(uint idVeiculo);
-        IEnumerable<Veiculo> GetPaged(int page, int lenght);
-        IEnumerable<Veiculo> GetAll();
-        IEnumerable<VeiculoDTO> GetVeiculoDTO();
+        IEnumerable<Veiculo> GetPaged(int page, int lenght, int idFrota);
+        IEnumerable<Veiculo> GetAll(int idFrota);
+        IEnumerable<VeiculoDTO> GetVeiculoDTO(int idFrota);
     }
 }
 

--- a/Codigo/Frota/FrotaWeb/Controllers/AbastecimentoController.cs
+++ b/Codigo/Frota/FrotaWeb/Controllers/AbastecimentoController.cs
@@ -1,6 +1,5 @@
 ﻿using AutoMapper;
 using Core;
-using Core.Datatables;
 using Core.Service;
 using FrotaWeb.Models;
 using Microsoft.AspNetCore.Authorization;
@@ -24,16 +23,10 @@ namespace FrotaWeb.Controllers
         // GET: AbastecimentoController
         public ActionResult Index([FromRoute] int page = 0)
         {
-            var listaAbastecimentos = abastecimentoService.GetAll();
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
+            var listaAbastecimentos = abastecimentoService.GetAll(idFrota);
             var listaAbastecimentosViewModel = mapper.Map<List<AbastecimentoViewModel>>(listaAbastecimentos);
             return View(listaAbastecimentosViewModel);
-        }
-
-        [HttpPost]
-        public IActionResult GetDataPage(DatatableRequest request)
-        {
-            var response = abastecimentoService.GetDataPage(request);
-            return Json(response);
         }
 
         // GET: AbastecimentoController/Details/5
@@ -53,12 +46,14 @@ namespace FrotaWeb.Controllers
         // POST: AbastecimentoController/Create
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Create(AbastecimentoViewModel abastecimento)
+        public ActionResult Create(AbastecimentoViewModel abastecimentoViewModel)
         {
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
+
             if (ModelState.IsValid)
             {
-                var _abastecimento = mapper.Map<Abastecimento>(abastecimento);
-                abastecimentoService.Create(_abastecimento);
+                var abastecimento = mapper.Map<Abastecimento>(abastecimentoViewModel);
+                abastecimentoService.Create(abastecimento, idFrota);
             }
 
             return RedirectToAction(nameof(Index));
@@ -75,12 +70,14 @@ namespace FrotaWeb.Controllers
         // POST: AbastecimentoController/Edit/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Edit(uint id, AbastecimentoViewModel abastecimento)
+        public ActionResult Edit(uint id, AbastecimentoViewModel abastecimentoViewModel)
         {
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
+
             if (ModelState.IsValid)
             {
-                var _abastecimento = mapper.Map<Abastecimento>(abastecimento);
-                abastecimentoService.Edit(_abastecimento);
+                var abastecimento = mapper.Map<Abastecimento>(abastecimentoViewModel);
+                abastecimentoService.Edit(abastecimento, idFrota);
             }
 
             return RedirectToAction(nameof(Index));
@@ -97,7 +94,7 @@ namespace FrotaWeb.Controllers
         // POST: AbastecimentoController/Delete/5
         [HttpPost]
         [ValidateAntiForgeryToken]
-        public ActionResult Delete(uint id, AbastecimentoViewModel abastecimento)
+        public ActionResult Delete(uint id, AbastecimentoViewModel abastecimentoViewModel)
         {
             abastecimentoService.Delete(id);
             return RedirectToAction(nameof(Index));

--- a/Codigo/Frota/FrotaWeb/Controllers/FrotaController.cs
+++ b/Codigo/Frota/FrotaWeb/Controllers/FrotaController.cs
@@ -32,7 +32,7 @@ namespace FrotaWeb.Controllers
         // GET: FrotaController/Details/5
         public ActionResult Details(uint id)
         {
-            Frotum frota = frotaService.Get(id);
+            Frotum frota = frotaService.Get((int)id);
             var frotaModel = mapper.Map<FrotaViewModel>(frota);
             return View(frotaModel);
         }
@@ -67,7 +67,7 @@ namespace FrotaWeb.Controllers
         [HttpGet]
         public ActionResult Edit(uint id)
         {
-            var frota = frotaService.Get(id);
+            var frota = frotaService.Get((int)id);
             var frotaModel = mapper.Map<FrotaViewModel>(frota);
             return View(frotaModel);
         }
@@ -96,7 +96,7 @@ namespace FrotaWeb.Controllers
         [HttpGet]
         public ActionResult Delete(uint id)
         {
-            Frotum frota = frotaService.Get(id);
+            Frotum frota = frotaService.Get((int)id);
             var frotaModel = mapper.Map<FrotaViewModel>(frota);
             return View(frotaModel);
         }
@@ -108,7 +108,7 @@ namespace FrotaWeb.Controllers
         {
             try
             {
-                frotaService.Delete(id);
+                frotaService.Delete((int)id);
                 return RedirectToAction(nameof(Index));
             }
             catch

--- a/Codigo/Frota/FrotaWeb/Controllers/PessoaController.cs
+++ b/Codigo/Frota/FrotaWeb/Controllers/PessoaController.cs
@@ -15,6 +15,7 @@ namespace FrotaWeb.Controllers
     {
         private readonly IPessoaService pessoaService;
         private readonly IMapper mapper;
+        
 
         public PessoaController(IPessoaService pessoaService, IMapper mapper)
         {
@@ -28,11 +29,12 @@ namespace FrotaWeb.Controllers
         [Route("Pessoa")]
         public ActionResult Index([FromRoute] int page = 0, string search = null, string filterBy = "Nome")
         {
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
             int length = 13;
             int totalResultados;
-            var listaPessoas = pessoaService.GetPaged(page, length, out totalResultados, search, filterBy).ToList();
+            var listaPessoas = pessoaService.GetPaged(idFrota, page, length, out totalResultados, search, filterBy).ToList();
 
-            var totalPessoas = pessoaService.GetAll().Count();
+            var totalPessoas = pessoaService.GetAll(idFrota).Count();
             var totalPages = (int)Math.Ceiling((double)totalResultados / length);
 
             ViewBag.CurrentPage = page;
@@ -68,10 +70,12 @@ namespace FrotaWeb.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Create(PessoaViewModel pessoaModel)
         {
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
+
             if (ModelState.IsValid)
             {
                 var pessoa = mapper.Map<Pessoa>(pessoaModel);
-                pessoaService.Create(pessoa);
+                pessoaService.Create(pessoa, idFrota);
             }
             return RedirectToAction(nameof(Index));
         }
@@ -89,10 +93,12 @@ namespace FrotaWeb.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Edit(uint id, PessoaViewModel pessoaModel)
         {
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
+
             if (ModelState.IsValid)
             {
                 var pessoa = mapper.Map<Pessoa>(pessoaModel);
-                pessoaService.Edit(pessoa);
+                pessoaService.Edit(pessoa, idFrota);
             }
             return RedirectToAction(nameof(Index));
         }

--- a/Codigo/Frota/FrotaWeb/Controllers/VeiculoController.cs
+++ b/Codigo/Frota/FrotaWeb/Controllers/VeiculoController.cs
@@ -4,6 +4,7 @@ using Core.Service;
 using FrotaWeb.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace FrotaWeb.Controllers
 {
@@ -31,10 +32,12 @@ namespace FrotaWeb.Controllers
         [Route ("Veiculo")]
         public ActionResult Index([FromRoute] int page = 0)
         {
-            int length = 15;
-            var listaVeiculos = veiculoService.GetPaged(page, length).ToList();
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
 
-            var totalVeiculos = veiculoService.GetAll().Count();
+            int length = 15;
+            var listaVeiculos = veiculoService.GetPaged(page, length, idFrota).ToList();
+
+            var totalVeiculos = veiculoService.GetAll(idFrota).Count();
             var totalPages = (int)Math.Ceiling((double)totalVeiculos / length);
 
             ViewBag.CurrentPage = page;
@@ -67,9 +70,10 @@ namespace FrotaWeb.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Create(VeiculoViewModel veiculoViewModel)
         {
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
             if (ModelState.IsValid) {
                 var veiculo = mapper.Map<Veiculo>(veiculoViewModel);
-                veiculoService.Create(veiculo);
+                veiculoService.Create(veiculo, idFrota);
             }
             return RedirectToAction(nameof(Index));
         }
@@ -87,9 +91,10 @@ namespace FrotaWeb.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Edit(uint id, VeiculoViewModel veiculoViewModel)
         {
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
             if (ModelState.IsValid) {
                 var veiculo = mapper.Map<Veiculo>(veiculoViewModel);
-                veiculoService.Edit(veiculo);
+                veiculoService.Edit(veiculo, idFrota);
             }
 
             return RedirectToAction(nameof(Index));

--- a/Codigo/Frota/FrotaWeb/Controllers/VeiculoPecaInsumoController.cs
+++ b/Codigo/Frota/FrotaWeb/Controllers/VeiculoPecaInsumoController.cs
@@ -14,6 +14,7 @@ namespace FrotaWeb.Controllers
         private readonly IMapper mapper;
         private readonly IVeiculoService veiculoService;
         private readonly IPecaInsumoService pecaInsumoService;
+        
 
         public VeiculoPecaInsumoController(IVeiculoPecaInsumoService service, IMapper mapper, IVeiculoService veiculoService, IPecaInsumoService pecaInsumoService)
         {
@@ -42,7 +43,8 @@ namespace FrotaWeb.Controllers
         // GET: VeiculoPecaInsumoController/Create
         public ActionResult Create()
         {
-            ViewData["Veiculos"] = this.veiculoService.GetVeiculoDTO();
+            int.TryParse(User.Claims.FirstOrDefault(claim => claim.Type == "FrotaId").Value, out int idFrota);
+            ViewData["Veiculos"] = this.veiculoService.GetVeiculoDTO(idFrota);
             ViewData["PecaInsumos"] = this.pecaInsumoService.GetAll();
             return View();
         }

--- a/Codigo/Frota/FrotaWeb/Views/Abastecimento/Index.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/Abastecimento/Index.cshtml
@@ -20,9 +20,6 @@
                         @Html.DisplayNameFor(model => model.Id)
                     </th>
                     <th>
-                        @Html.DisplayNameFor(model => model.IdPercurso)
-                    </th>
-                    <th>
                         @Html.DisplayNameFor(model => model.IdFornecedor)
                     </th>
                     <th>
@@ -43,9 +40,6 @@
                     <tr>
                         <td>
                             @Html.DisplayFor(modelItem => item.Id)
-                        </td>
-                        <td>
-                            @Html.DisplayFor(modelItem => item.IdPercurso)
                         </td>
                         <td>
                             @Html.DisplayFor(modelItem => item.IdFornecedor)

--- a/Codigo/Frota/Service/AbastecimentoService.cs
+++ b/Codigo/Frota/Service/AbastecimentoService.cs
@@ -1,5 +1,4 @@
 ﻿using Core;
-using Core.Datatables;
 using Core.Service;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -28,9 +27,9 @@ namespace Service
         /// </summary>
         /// <param name="abastecimento"></param>
         /// <returns></returns>
-        public uint Create(Abastecimento abastecimento)
+        public uint Create(Abastecimento abastecimento, int idFrota)
         {
-            abastecimento.IdFrota = frotaService.GetFrotaByUser();
+            abastecimento.IdFrota = (uint)idFrota;
             abastecimento.IdPessoa = pessoaService.GetPessoaIdUser();
             context.Add(abastecimento);
             context.SaveChanges();
@@ -55,10 +54,10 @@ namespace Service
         /// Altera os dados da veiculo na base de dados
         /// </summary>
         /// <param name="abastecimento"></param>
-        public void Edit(Abastecimento abastecimento)
+        public void Edit(Abastecimento abastecimento, int idFrota)
         {
             abastecimento.IdPessoa = pessoaService.GetPessoaIdUser();
-            abastecimento.IdFrota = frotaService.GetFrotaByUser();
+            abastecimento.IdFrota = (uint)idFrota;
             context.Update(abastecimento);
             context.SaveChanges();
 
@@ -78,44 +77,15 @@ namespace Service
         /// Obter a lista de abastecimentos cadastradas
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<Abastecimento> GetAll()
+        public IEnumerable<Abastecimento> GetAll(int idFrota)
         {
-            return context.Abastecimentos.AsNoTracking();
+            return context.Abastecimentos.Where(abastecimento => abastecimento.IdFrota == idFrota).AsNoTracking();
         }
 
-        public DatatableResponse<Abastecimento> GetDataPage(DatatableRequest request)
-        {
-            uint idFrota = frotaService.GetFrotaByUser();
-            var abastecimentos = context.Abastecimentos.Where(abastecimentos => abastecimentos.IdFrota == idFrota).AsNoTracking();
-
-            var totalResults = abastecimentos.Count();
-
-            if (request.Search != null && request.Search.GetValueOrDefault("value") != null)
-            {
-                abastecimentos = abastecimentos.Where(abastecimentos => abastecimentos.Id.ToString().Contains(request.Search.GetValueOrDefault("value")));
-            }
-
-            if (request.Order != null && request.Order[0].GetValueOrDefault("column").Equals("0"))
-            {
-                if (request.Order[0].GetValueOrDefault("dir").Equals("asc"))
-                    abastecimentos = abastecimentos.OrderBy(abastecimentos => abastecimentos.Id);
-                else
-                    abastecimentos = abastecimentos.OrderByDescending(abastecimentos => abastecimentos.Id);
-            }
-            int countRecordsFiltered = abastecimentos.Count();
-            abastecimentos = abastecimentos.Skip(request.Start).Take(request.Length);
-            return new DatatableResponse<Abastecimento>
-            {
-                Data = abastecimentos.ToList(),
-                Draw = request.Draw,
-                RecordsFiltered = countRecordsFiltered,
-                RecordsTotal = totalResults
-            };
-        }
-
-        public IEnumerable<Abastecimento> GetPaged(int page, int lenght)
+        public IEnumerable<Abastecimento> GetPaged(int page, int lenght, int idFrota)
         {
             return context.Abastecimentos
+                          .Where(abastecimento => abastecimento.IdFrota == idFrota)
                           .AsNoTracking()
                           .Skip(page * lenght)
                           .Take(lenght);

--- a/Codigo/Frota/Service/FrotaService.cs
+++ b/Codigo/Frota/Service/FrotaService.cs
@@ -35,7 +35,7 @@ namespace Service
         /// </summary>
         /// <param name="idFrota"></param>
         /// <returns>retorna verdadeiro se o registro for removido</returns>
-        public bool Delete(uint idFrota)
+        public bool Delete(int idFrota)
         {
             var frota = context.Frota.Find(idFrota);
             if (frota != null)
@@ -62,35 +62,32 @@ namespace Service
         /// </summary>
         /// <param name="idFrota"></param>
         /// <returns>retorna o objeto ou um valor nulo</returns>
-        public Frotum? Get(uint idFrota)
+        public Frotum? Get(int idFrota)
         {
             return context.Frota.Find(idFrota);
 
         }
 
         /// <summary>
-        /// Obter o id da frota através do usuário autenticado
+        /// Método para obter o id da frota do usuário que fizer a autenticação
         /// </summary>
-        /// <returns>Id do Frota</returns>
+        /// <param name="username"></param>
+        /// <returns>id da frota</returns>
         /// <exception cref="UnauthorizedAccessException"></exception>
         /// <exception cref="InvalidOperationException"></exception>
-        public uint GetFrotaByUser()
+        public uint GetFrotaByUsername(string username)
         {
-            var cpf = httpContextAccessor.HttpContext?.User?.Identity?.Name;
+            if (string.IsNullOrEmpty(username))
+                throw new UnauthorizedAccessException("Usuário não encontrado.");
 
-            if (string.IsNullOrEmpty(cpf))
-            {
-                throw new UnauthorizedAccessException("Usuário não autenticado.");
-            }
             var idFrota = context.Pessoas
                                  .AsNoTracking()
-                                 .Where(p => p.Cpf == cpf)
+                                 .Where(p => p.Cpf == username)
                                  .Select(p => p.IdFrota)
                                  .FirstOrDefault();
+
             if (idFrota == 0)
-            {
                 throw new InvalidOperationException("Frota não encontrada para o usuário autenticado.");
-            }
             return idFrota;
         }
 

--- a/Codigo/Frota/Service/PessoaService.cs
+++ b/Codigo/Frota/Service/PessoaService.cs
@@ -25,8 +25,9 @@ namespace Service
         /// <param name="pessoa"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public uint Create(Pessoa pessoa)
+        public uint Create(Pessoa pessoa, int idFrota)
         {
+            pessoa.IdFrota = (uint)idFrota;
             context.Add(pessoa);
             context.SaveChanges();
             return pessoa.Id;
@@ -52,8 +53,9 @@ namespace Service
         /// </summary>
         /// <param name="pessoa"></param>
         /// <exception cref="NotImplementedException"></exception>
-        public void Edit(Pessoa pessoa)
+        public void Edit(Pessoa pessoa, int idFrota)
         {
+            pessoa.IdFrota = (uint)idFrota;
             context.Update(pessoa);
             context.SaveChanges();
         }
@@ -73,9 +75,8 @@ namespace Service
         /// Busca todas as pessoas cadastradas
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<Pessoa> GetAll()
+        public IEnumerable<Pessoa> GetAll(int idFrota)
         {
-            uint idFrota = frotaService.GetFrotaByUser();
             return context.Pessoas
                           .AsNoTracking()
                           .Where(f => f.IdFrota == idFrota)
@@ -100,10 +101,8 @@ namespace Service
             return idPessoa;
         }
 
-        public IEnumerable<Pessoa> GetPaged(int page, int lenght, out int totalResults, string search = null, string filterBy = "Nome")
+        public IEnumerable<Pessoa> GetPaged(int idFrota, int page, int lenght, out int totalResults, string search = null, string filterBy = "Nome")
         {
-            uint idFrota = frotaService.GetFrotaByUser();
-
             var query = context.Pessoas
                                .Where(f => f.IdFrota == idFrota)
                                .AsNoTracking();

--- a/Codigo/Frota/Service/VeiculoService.cs
+++ b/Codigo/Frota/Service/VeiculoService.cs
@@ -24,7 +24,7 @@ namespace Service
         /// </summary>
         /// <param name="veiculo"></param>
         /// <returns></returns>
-        public uint Create(Veiculo veiculo)
+        public uint Create(Veiculo veiculo, int idFrota)
         {
             context.Add(veiculo);
             context.SaveChanges();
@@ -49,7 +49,7 @@ namespace Service
         /// Altera os dados da veiculo na base de dados
         /// </summary>
         /// <param name="veiculo"></param>
-        public void Edit(Veiculo veiculo)
+        public void Edit(Veiculo veiculo, int idFrota)
         {
             context.Update(veiculo);
             context.SaveChanges();
@@ -69,10 +69,8 @@ namespace Service
         /// Obter a lista de veiculo cadastradas
         /// </summary>
         /// <returns></returns>
-        public IEnumerable<Veiculo> GetAll()
+        public IEnumerable<Veiculo> GetAll(int idFrota)
         {
-            uint idFrota = frotaService.GetFrotaByUser();
-
             return context.Veiculos
                           .AsNoTracking()
                           .Where(v => v.IdFrota == idFrota).OrderBy(v => v.Id);
@@ -84,10 +82,8 @@ namespace Service
         /// <param name="page"></param>
         /// <param name="lenght"></param>
         /// <returns>Lista de veículos</returns>
-        public IEnumerable<Veiculo> GetPaged(int page, int lenght)
+        public IEnumerable<Veiculo> GetPaged(int page, int lenght, int idFrota)
         {
-            uint idFrota = frotaService.GetFrotaByUser();
-
             return context.Veiculos
                           .AsNoTracking()
                           .Where(v => v.IdFrota == idFrota)
@@ -100,9 +96,10 @@ namespace Service
         /// Obtém uma listagem simplificada de veículos
         /// </summary>
         /// <returns>Retorna uma listagem de VeiculosDTO</returns>
-        public IEnumerable<VeiculoDTO> GetVeiculoDTO()
+        public IEnumerable<VeiculoDTO> GetVeiculoDTO(int idFrota)
         {
             var veiculoDTO = from veiculo in context.Veiculos
+                             where veiculo.IdFrota == idFrota
                              join modelo in context.Modeloveiculos
                              on veiculo.IdModeloVeiculo equals modelo.Id
                              orderby veiculo.Id


### PR DESCRIPTION
Durante a implementação foi percebido que persistir o id da frota do usuário na sessão era válida para o caso de uso em que ele autenticava momentos antes de acessar alguma controller, mas ao reiniciar o navegador e realizar a autenticação automática por meio de cookies não era possível recuperar o id da frota novamente. Diante disso, o valor foi persistido em um novo Claim, adicionado para evitar esse possível valor nulo. 

Além disso, algumas classes de serviço foram alteradas para considerar apenas os do banco da respectiva frota.