### PR TITLE
Feat: melhoria de algumas views de detalhes de cadastros, definição inicial de padronização

### DIFF
--- a/Codigo/Frota/FrotaApi/Controllers/AbastecimentoController.cs
+++ b/Codigo/Frota/FrotaApi/Controllers/AbastecimentoController.cs
@@ -9,7 +9,6 @@ namespace FrotaApi.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
-    [Authorize(Roles = "Gestor, Motorista")]
     public class AbastecimentoController : ControllerBase
     {
         private readonly IAbastecimentoService _abastecimentoService;

--- a/Codigo/Frota/FrotaWeb/FrotaWeb.csproj.user
+++ b/Codigo/Frota/FrotaWeb/FrotaWeb.csproj.user
@@ -11,6 +11,6 @@
     <WebStackScaffolding_ControllerDialogWidth>650.4</WebStackScaffolding_ControllerDialogWidth>
     <Controller_SelectedScaffolderID>MvcControllerWithActionsScaffolder</Controller_SelectedScaffolderID>
     <Controller_SelectedScaffolderCategoryPath>root/Common/MVC/Controller</Controller_SelectedScaffolderCategoryPath>
-    <NameOfLastUsedPublishProfile>F:\Projetos\Trabalho\FrotaPublica\Codigo\Frota\FrotaWeb\Properties\PublishProfiles\itetech-001-site6 - Web Deploy1.pubxml</NameOfLastUsedPublishProfile>
+    <NameOfLastUsedPublishProfile>F:\Projetos\Trabalho\FrotaPublica\Codigo\Frota\FrotaWeb\Properties\PublishProfiles\itetech-001-site5 - Web Deploy.pubxml</NameOfLastUsedPublishProfile>
   </PropertyGroup>
 </Project>

--- a/Codigo/Frota/FrotaWeb/Views/Abastecimento/Details.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/Abastecimento/Details.cshtml
@@ -1,6 +1,8 @@
 ﻿@model FrotaWeb.Models.AbastecimentoViewModel
 
-<div>
+<link rel="stylesheet" href="~/css/details.css" asp-append-version="true" />
+
+<div class="container-details">
     <h4>AbastecimentoViewModel</h4>
     <hr />
     <dl class="row">
@@ -54,7 +56,7 @@
         </dd>
     </dl>
 </div>
-<div>
+<div class="container-buttons">
     @Html.ActionLink("Edit", "Edit", new { /* id = Model.PrimaryKey */ }) |
     <a asp-action="Index">Back to List</a>
 </div>

--- a/Codigo/Frota/FrotaWeb/Views/Fornecedor/Details.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/Fornecedor/Details.cshtml
@@ -1,6 +1,8 @@
 ﻿@model FrotaWeb.Models.FornecedorViewModel
 
-<div>
+<link rel="stylesheet" href="~/css/details.css" asp-append-version="true" />
+
+<div class="container-details">
     <h4>FornecedorViewModel</h4>
     <hr />
     <dl class="row">
@@ -90,7 +92,7 @@
         </dd>
     </dl>
 </div>
-<div>
+<div class="container-buttons">
     @Html.ActionLink("Edit", "Edit", new { /* id = Model.PrimaryKey */ }) |
     <a asp-action="Index">Back to List</a>
 </div>

--- a/Codigo/Frota/FrotaWeb/Views/Frota/Details.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/Frota/Details.cshtml
@@ -1,12 +1,8 @@
 ﻿@model FrotaWeb.Models.FrotaViewModel
 
-@{
-    ViewData["Title"] = "Details";
-}
+<link rel="stylesheet" href="~/css/details.css" asp-append-version="true" />
 
-<h1>Details</h1>
-
-<div>
+<div class="container-details">
     <h4>FrotaViewModel</h4>
     <hr />
     <dl class="row">
@@ -72,7 +68,7 @@
         </dd>
     </dl>
 </div>
-<div>
+<div class="container-buttons">
     <a href="@Url.Action("Edit", "Frota", new { id = Model.Id })" class="edit" title="Editar" data-toggle="tooltip">
         <i class="fa fa-pencil-alt cor" aria-hidden="true"></i>
     </a> |

--- a/Codigo/Frota/FrotaWeb/Views/Home/Index.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/Home/Index.cshtml
@@ -19,17 +19,6 @@
     </section>
     @if (Model.UserType == "Motorista")
     {
-        <section class="atalhos">
-            <div class="titulo-section">
-                <h1>Atalhos</h1>
-            </div>
-            <div class="atalhos">
-                <button class="atalho">
-                    <span class="material-symbols-outlined">build</span>
-                    <p>Adicionar Atalho</p>
-                </button>
-            </div>
-        </section>
         <section>
             <div class="titulo-section">
                 <h1>Lembretes</h1>
@@ -47,17 +36,6 @@
     }
     else if (Model.UserType == "Gestor")
     {
-        <section class="atalhos">
-            <div class="titulo-section">
-                <h1>Atalhos</h1>
-            </div>
-            <div class="atalhos">
-                <button class="atalho">
-                    <img src="./driver.png" alt="">
-                    <p>Adicionar Atalho</p>
-                </button>
-            </div>
-        </section>
         <section>
             <div class="titulo-section">
                 <h1>Lembretes</h1>
@@ -75,17 +53,6 @@
     }
     else if (Model.UserType == "Administrador")
     {
-        <section class="atalhos">
-            <div class="titulo-section">
-                <h1>Atalhos</h1>
-            </div>
-            <div class="atalhos">
-                <button class="atalho">
-                    <img src="./driver.png" alt="">
-                    <p>Adicionar Atalho</p>
-                </button>
-            </div>
-        </section>
         <section>
             <div class="titulo-section">
                 <h1>Lembretes</h1>
@@ -103,17 +70,6 @@
     }
     else if (Model.UserType == "Mecanico")
     {
-        <section class="atalhos">
-            <div class="titulo-section">
-                <h1>Atalhos</h1>
-            </div>
-            <div class="atalhos">
-                <button class="atalho">
-                    <img src="./driver.png" alt="">
-                    <p>Adicionar Atalho</p>
-                </button>
-            </div>
-        </section>
         <section>
             <div class="titulo-section">
                 <h1>Lembretes</h1>

--- a/Codigo/Frota/FrotaWeb/Views/Manutencao/Details.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/Manutencao/Details.cshtml
@@ -1,13 +1,9 @@
 ﻿@model FrotaWeb.Models.ManutencaoViewModel
 
-@{
-    ViewData["Title"] = "Details";
-}
+<link rel="stylesheet" href="~/css/details.css" asp-append-version="true" />
 
-<h1>Details</h1>
-
-<div>
-    <h4>ManutencaoViewModel</h4>
+<div class="container-details">
+    <h4>Manutencao</h4>
     <hr />
     <dl class="row">
         <dt class = "col-sm-2">
@@ -72,7 +68,7 @@
         </dd>
     </dl>
 </div>
-<div>
+<div class="container-buttons">
     @Html.ActionLink("Edit", "Edit", new { /* id = Model.PrimaryKey */ }) |
     <a asp-action="Index">Back to List</a>
 </div>

--- a/Codigo/Frota/FrotaWeb/Views/ManutencaoPecaInsumo/Details.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/ManutencaoPecaInsumo/Details.cshtml
@@ -1,6 +1,8 @@
 ﻿@model FrotaWeb.Models.ManutencaoPecaInsumoViewModel
 
-<div>
+<link rel="stylesheet" href="~/css/details.css" asp-append-version="true" />
+
+<div class="container-details">
 	<h4>ManutencaoPecaInsumoViewModel</h4>
 	<hr />
 	<dl class="row">
@@ -54,7 +56,7 @@
 		</dd>
 	</dl>
 </div>
-<div>
+<div class="container-buttons">
 	@Html.ActionLink("Edit", "Edit", new { idManutencao = Model.IdManutencao, idPecaInsumo = Model.IdPecaInsumo }) |
 	<a asp-action="Index">Back to List</a>
 </div>

--- a/Codigo/Frota/FrotaWeb/Views/Percurso/Details.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/Percurso/Details.cshtml
@@ -1,12 +1,8 @@
 ﻿@model FrotaWeb.Models.PercursoViewModel
 
-@{
-    ViewData["Title"] = "Details";
-}
+<link rel="stylesheet" href="~/css/details.css" asp-append-version="true" />
 
-<h1>Details</h1>
-
-<div>
+<div class="container-details">
     <h4>PercursoViewModel</h4>
     <hr />
     <dl class="row">
@@ -96,7 +92,7 @@
         </dd>
     </dl>
 </div>
-<div>
+<div class="container-buttons">
     @Html.ActionLink("Edit", "Edit", new { /* id = Model.PrimaryKey */ }) |
     <a asp-action="Index">Back to List</a>
 </div>

--- a/Codigo/Frota/FrotaWeb/Views/Pessoa/Create.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/Pessoa/Create.cshtml
@@ -28,7 +28,7 @@
             </div>
             <div class="form-group w30">
                 <label asp-for="Cpf" class="control-label"></label>
-                <input asp-for="Cpf" class="form-control" />
+                <input asp-for="Cpf" class="form-control" data-mask="000.000.000-00" placeholder="000.000.000-00" />
                 <span asp-validation-for="Cpf" class="text-danger"></span>
             </div>
             <div class="form-group w60">
@@ -44,7 +44,7 @@
             <hr class="divisor">
             <div class="form-group w40">
                 <label asp-for="Cep" class="control-label"></label>
-                <input asp-for="Cep" class="form-control" id="cep" maxlength="9" />
+                <input asp-for="Cep" class="form-control" id="cep" maxlength="9" data-mask="00000-000" placeholder="00000-000" />
                 <span asp-validation-for="Cep" class="text-danger"></span>
             </div>
             <div class="form-group w50">

--- a/Codigo/Frota/FrotaWeb/Views/Pessoa/Details.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/Pessoa/Details.cshtml
@@ -1,6 +1,8 @@
 ﻿@model FrotaWeb.Models.PessoaViewModel
 
-<div>
+<link rel="stylesheet" href="~/css/details.css" asp-append-version="true" />
+
+<div class="container-details">
     <h4>PessoaViewModel</h4>
     <hr />
     <dl class="row">
@@ -102,7 +104,7 @@
         </dd>
     </dl>
 </div>
-<div>
+<div class="container-buttons">
     @Html.ActionLink("Edit", "Edit", new { /* id = Model.PrimaryKey */ }) |
     <a asp-action="Index">Back to List</a>
 </div>

--- a/Codigo/Frota/FrotaWeb/Views/VeiculoPecaInsumo/Details.cshtml
+++ b/Codigo/Frota/FrotaWeb/Views/VeiculoPecaInsumo/Details.cshtml
@@ -6,9 +6,9 @@
     viewModel = Model;
 }
 
-<h1>Details</h1>
+<link rel="stylesheet" href="~/css/details.css" asp-append-version="true" />
 
-<div>
+<div class="container-details">
     <h4>VeiculoPecaInsumoViewModel</h4>
     <hr />
     <dl class="row">
@@ -50,7 +50,7 @@
         </dd>
     </dl>
 </div>
-<div>
+<div class="container-buttons">
     <a asp-controller="VeiculoPecaInsumo"
        asp-action="Edit"
        asp-route-idVeiculo="@viewModel.IdVeiculo"

--- a/Codigo/Frota/FrotaWeb/wwwroot/css/details.css
+++ b/Codigo/Frota/FrotaWeb/wwwroot/css/details.css
@@ -1,0 +1,68 @@
+﻿/* Container principal */
+.container-details {
+    margin-top: 50px
+}
+
+/* Título */
+h4 {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #0C69AB;
+    margin-bottom: 16px;
+}
+
+/* Separador */
+hr {
+    border: 0;
+    height: 1px;
+    background-color: #E5E7EB;
+    margin: 16px 0;
+}
+
+/* Labels e valores */
+dl {
+    display: flex;
+    flex-wrap: wrap;
+    margin: 0;
+    padding: 0;
+}
+
+dt {
+    font-weight: bold;
+    color: #4B5563;
+    margin-bottom: 8px;
+}
+
+dd {
+    margin-left: 0;
+    margin-bottom: 8px;
+}
+
+/* Estilização dos botões */
+.container-buttons > a, div > button {
+    display: inline-block;
+    background-color: #0C69AB;
+    color: #FFFFFF;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 16px;
+    text-decoration: none;
+    font-size: 0.9rem;
+    font-weight: bold;
+    text-align: center;
+    transition: background-color 0.3s ease;
+    cursor: pointer;
+}
+
+    .container-buttons > a:hover, div > button:hover {
+        background-color: #08568B;
+    }
+
+    .container-buttons > a:last-child {
+        background-color: #F1F5F9;
+        color: #333;
+    }
+
+        .container-buttons > a:last-child:hover {
+            background-color: #E2E8F0;
+        }

--- a/Codigo/Frota/FrotaWeb/wwwroot/css/details.css
+++ b/Codigo/Frota/FrotaWeb/wwwroot/css/details.css
@@ -1,6 +1,6 @@
 ﻿/* Container principal */
 .container-details {
-    margin-top: 50px
+    margin-top: 50px;
 }
 
 /* Título */

--- a/Codigo/Frota/FrotaWeb/wwwroot/css/form-pages.css
+++ b/Codigo/Frota/FrotaWeb/wwwroot/css/form-pages.css
@@ -1,6 +1,5 @@
 ﻿/* Estilização genérica para páginas */
 body {
-    font-family: 'Arial', sans-serif;
     background-color: #f8f9fa;
 }
 


### PR DESCRIPTION
<div align="center">
  <img src="https://github.com/user-attachments/assets/30c30a22-abdb-48e0-a4ae-6994ab158d92" width="10%">
  <h1>Pull Request</h1> 
</div>


## Foi Solicitado
Foi melhorada a visualização de algumas views de detalhes e definição inicial de um protótipo de padronização dessas telas.

## Foi Feito
- [x] Criação de um css padrão para todas as telas de detalhes que houverem na aplicação web
- [x] Melhoria de algumas telas já existentes para ficarem nesse novo padrão

## Como Testar
Basta navegar até as telas de detalhes de alguns cadastros

**Certifique-se de revisar o código e testar as alterações localmente antes de solicitar/fazer o merge.**
